### PR TITLE
Block length method excludes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    codecademy-style (0.1.1)
+    codecademy-style (0.1.2)
       rubocop
 
 GEM

--- a/default.yml
+++ b/default.yml
@@ -2,6 +2,10 @@ Metrics/BlockLength:
   Exclude:
     - 'spec/**/*.rb'
     - '**/*.gemspec'
+  ExcludedMethods:
+    - 'included' # ActiveSupport concerns
+    - 'namespace' # rake tasks
+    - 'task' # rake tasks
 
 Metrics/LineLength:
   Max: 100

--- a/lib/codecademy_style/version.rb
+++ b/lib/codecademy_style/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CodecademyStyle
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end


### PR DESCRIPTION
* `included`: You can put a whole ton of methods in here and it's fine in an active support concern.
* `namespace` and `task`: These are part of the Rake DSL. `namespace` is like `context` in RSpec in that it's just a container of logically discrete chunks, so we shouldn't be concerned with its overall length. You might push back on `task` because this is more like a method, but these tend to be very declarative with lots of logging, so I'm fine with them being long