### PR TITLE
Lock the rubocop version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    codecademy-style (0.1.2)
-      rubocop
+    codecademy-style (0.1.3)
+      rubocop (~> 0.79)
 
 GEM
   remote: https://rubygems.org/
@@ -10,18 +10,18 @@ GEM
     ast (2.4.0)
     jaro_winkler (1.5.4)
     parallel (1.19.1)
-    parser (2.6.5.0)
+    parser (2.7.0.2)
       ast (~> 2.4.0)
     rainbow (3.0.0)
-    rubocop (0.77.0)
+    rubocop (0.79.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.6)
+      parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
     ruby-progressbar (1.10.1)
-    unicode-display_width (1.6.0)
+    unicode-display_width (1.6.1)
 
 PLATFORMS
   ruby
@@ -29,7 +29,7 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 1.17)
   codecademy-style!
-  rubocop (~> 0.77)
+  rubocop (~> 0.79)
 
 BUNDLED WITH
    1.17.3

--- a/codecademy-style.gemspec
+++ b/codecademy-style.gemspec
@@ -35,8 +35,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   # Require clients of this gem to have RuboCop installed
-  spec.add_dependency 'rubocop'
+  spec.add_dependency 'rubocop', '~> 0.79'
 
   spec.add_development_dependency 'bundler', '~> 1.17'
-  spec.add_development_dependency 'rubocop', '~> 0.77'
+  spec.add_development_dependency 'rubocop', '~> 0.79'
 end

--- a/lib/codecademy_style/version.rb
+++ b/lib/codecademy_style/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CodecademyStyle
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end


### PR DESCRIPTION
Not a good look to have Rubocop randomly updating in apps that install this gem.